### PR TITLE
Update Consistent Snapshots section

### DIFF
--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -542,37 +542,48 @@ that disagrees with what is available on PyPI, which is indistinguishable from
 arbitrary metadata injected by an attacker.  The problem would also occur for
 mirrors attempting to sync with PyPI.
 
-
 Consistent Snapshots
 --------------------
 
-There are problems with consistency on PyPI with or without TUF.  TUF requires
-that its metadata be consistent with the repository files, but how would the
-metadata be kept consistent with projects that change all the time?  As a
-result, this proposal MUST address the problem of producing a consistent
-snapshot that captures the state of all known projects at a given time.  Each
-snapshot should safely coexist with any other snapshot, and be able to be
-deleted independently, without affecting any other snapshot.
+To keep TUF metadata on PyPI consistent with the highly volatile target files,
+consistent snapshots SHOULD be used. Each consistent snapshot captures the
+state of all known projects at a given time and MAY safely coexist with any
+other snapshot, or be deleted independently, without affecting any other
+snapshot.
 
-The solution presented in this PEP is that every metadata or data file managed
-by PyPI and written to disk MUST include in its filename the `cryptographic
-hash`__ of the file.  How would this help clients that use the TUF protocol to
-securely and consistently install or update a project from PyPI?
+To maintain consistent snapshots, all TUF metadata MUST, when written to disk,
+include a version number in their filename:
+
+  VERSION_NUMBER.ROLENAME.json,
+    where VERSION_NUMBER is an incrementing integer, and ROLENAME is one of the
+    top-level metadata roles -- *root*, *snapshot* or *targets* -- or one of
+    the delegated targets roles -- *bins* or *bin <i>*.
+
+The only exception is the *timestamp* metadata file, whose version is not known
+in advance, when a client performs an update.
+
+Instead the *timestamp* metadata serves as version root. That is, it lists the
+version of the *snapshot* metadata, which in turn lists the versions of *root*,
+*targets* and delegated targets metadata, all part of a given consistent
+snapshot.
+
+Eventually, *targets* or delegated targets metadata point to the actual target
+files, including their `cryptographic hashes`__. Thus, to mark a target file as
+part of a consistent snapshot it MUST, when written to disk, include its hash
+in its filename:
+
+  HASH.FILENAME
+    where HASH is the `hex digest`__ of the `SHA-256`__ hash of the file
+    contents and FILENAME is the original filename.
 
 __ https://en.wikipedia.org/wiki/Cryptographic_hash_function
+__ https://docs.python.org/3.7/library/hashlib.html#hashlib.hash.hexdigest
+__ https://en.wikipedia.org/wiki/SHA-2
 
-The first step in the TUF protocol requires the client to download the latest
-*timestamp* metadata.  However, the client would not know in advance the hash
-of the *timestamp* associated with the latest snapshot.  Therefore, PyPI MUST
-redirect all HTTP GET requests for *timestamp* to the *timestamp* referenced in
-the latest snapshot.  The *timestamp* role is the root of a tree of
-cryptographic hashes that points to every other metadata that is meant to exist
-together (i.e., clients request metadata in timestamp -> snapshot -> root ->
-targets order).  Clients are able to retrieve any file from this snapshot
-by deterministically including, in the request for the file, the hash of the
-file in the filename.  Assuming infinite disk space and no `hash collisions`__,
-a client may safely read from one snapshot while PyPI produces another
-snapshot.
+
+Assuming infinite disk space, strictly incrementing version numbers, and no
+`hash collisions`__, a client may safely read from one snapshot while PyPI
+produces another snapshot.
 
 __ https://en.wikipedia.org/wiki/Collision_(computer_science)
 
@@ -597,14 +608,6 @@ MUST upload its release in a single transaction.  The uploaded set of files is
 called the "project transaction".  How PyPI MAY validate the files in a project
 transaction is discussed in a later section.  For now, the focus is on how PyPI
 will respond to a project transaction.
-
-Every metadata and target file MUST include in its filename the `hex digest`__
-of its `SHA-256`__ hash.  For this PEP, it is RECOMMENDED that PyPI adopt a
-simple convention of the form: digest.filename, where filename is the original
-filename without a copy of the hash, and digest is the hex digest of the hash.
-
-__ http://docs.python.org/2/library/hashlib.html#hashlib.hash.hexdigest
-__ https://en.wikipedia.org/wiki/SHA-2
 
 When a project uploads a new transaction, the project transaction process MUST
 add all new targets and relevant delegated *bins* metadata.  (It is shown later
@@ -670,10 +673,8 @@ snapshot.
 
 All clients, such as pip using the TUF protocol, MUST be modified to download
 every metadata and target file (except for *timestamp* metadata) by including,
-in the request for the file, the cryptographic hash of the file in the
-filename.  Following the filename convention recommended earlier, a request for
-the file at filename.ext will be transformed to the equivalent request for the
-file at digest.filename.
+in the request for the file, the version of the file (for metadata), or the
+cryptographic hash of the file (for target files) in the filename.
 
 Finally, PyPI SHOULD use a `transaction log`__ to record project transaction
 processes and queues so that it will be easier to recover from errors after a


### PR DESCRIPTION
consistent snapshots used to require a hash digest prefix in filenames for metadata and target files, now only target  files add a hash digest prefix and metadata uses a version number.
