### PR TITLE
Update link to client updater workflow

### DIFF
--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -373,7 +373,7 @@ root metadata and downloads the rest of the roles, including updating
 "root.json" if it has changed.  An `outline of the update process`__ is
 available.
 
-__ https://github.com/theupdateframework/tuf/tree/develop/tuf/client#overview-of-the-update-process.
+__ https://github.com/theupdateframework/specification/blob/master/tuf-spec.md#5-detailed-workflows.
 
 
 Minimum Security Model


### PR DESCRIPTION
The link used to point to outdated documentation in the reference implementation. This change updates the link to point to the up-to-date client workflow in the specification.