### PR TITLE
Clarify that targets file paths must be relative

### DIFF
--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -303,13 +303,12 @@ and *targets*.  The *root* role specifies the public cryptographic keys of the
 top-level roles (including its own).  The *timestamp* role references the
 latest *snapshot* and can signify when a new snapshot of the repository is
 available.  The *snapshot* role indicates the latest version of all the TUF
-metadata files (other than *timestamp*).  The *targets* role lists the
-available target files (in our case, it will be all files on PyPI under the
-/simple and /packages directories).  These target files do not need to be
-URIs or relative files on the same repository as long as they can be accessed
-by anyone performing an update.  Each top-level role will serve its
-responsibilities without exception.  Figure 1 provides a table of the roles
-used in TUF.
+metadata files (other than *timestamp*). The *targets* role lists the file
+paths of available target file together with their hashes. The file paths must
+be specified relative to a base URL. This allows the actual target files to be
+served from anywhere, as long as the base URL can be accessed by the client.
+Each top-level role will serve its responsibilities without exception.  Figure
+1 provides a table of the roles used in TUF.
 
 .. image:: pep-0458-1.png
 

--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -304,7 +304,7 @@ top-level roles (including its own).  The *timestamp* role references the
 latest *snapshot* and can signify when a new snapshot of the repository is
 available.  The *snapshot* role indicates the latest version of all the TUF
 metadata files (other than *timestamp*). The *targets* role lists the file
-paths of available target file together with their hashes. The file paths must
+paths of available target files together with their hashes. The file paths must
 be specified relative to a base URL. This allows the actual target files to be
 served from anywhere, as long as the base URL can be accessed by the client.
 Each top-level role will serve its responsibilities without exception.  Figure


### PR DESCRIPTION
Clarify that file paths of target files must be listed relative
to a root URL in the targets metadata, to allow serving target
files from anywhere.

This change also removes outdated information about the PyPI API,
see https://github.com/pypa/warehouse/blob/master/docs/api-reference/legacy.rst.