### PR TITLE
PEP 0458: clarify snapshot metadata compression

### DIFF
--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -457,14 +457,16 @@ pip for the first time.
 
 __ https://docs.google.com/spreadsheets/d/11_XkeHrf4GdhMYVqpYWsug6JNz5ZK6HvvmDZX0__K2I/edit?usp=sharing
 
-It is possible to make TUF metadata more compact by representing it in a binary
-format, as opposed to the JSON text format.  Nevertheless, a sufficiently large
+While it is possible to make TUF metadata more compact by representing it in a
+binary format, as opposed to the JSON text format, a sufficiently large
 number of projects and distributions will introduce scalability challenges at
 some point, and therefore the *bins* role will still need delegations (as
-outlined in figure 2) in order to address the problem.  Furthermore, the JSON
-format is an open and well-known standard for data interchange.  Due to the
-large number of delegated metadata, compressed versions of *snapshot* metadata
-SHOULD also be made available to clients.
+outlined in figure 2) in order to address the problem.  The JSON format is an
+open and well-known standard for data interchange, which is already supported by
+the TUF reference implementation, and therefore the recommended data format by
+this PEP.  However, due to the large number of delegations, compressed
+versions of all metadata SHOULD also be made available to clients via the
+existing Warehouse mechanisms for HTTP compression.
 
 
 PyPI and Key Requirements


### PR DESCRIPTION
The snapshot metadata compression should be handled at a separate
layer, as TUF doesn't provide compression (see TAP 10).

An attempt to address #20 
