### PR TITLE
Clarify targets delegation tree

### DIFF
--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -408,14 +408,20 @@ have any of the keys required to sign for projects.  However, it does not
 protect projects from attackers who have compromised PyPI, since they can
 then manipulate TUF metadata using the keys stored online.
 
-This PEP proposes that the *bin-n* roles sign for all
-PyPI projects with online keys.  The *targets* role, which only signs with an
-offline key, MUST delegate all PyPI projects to the *bins* role.  This means
-that when a package manager such as pip (i.e., using TUF) downloads a
-distribution from a project on PyPI, it will consult the *bins* role about the
-TUF metadata for the project.  If no *bin-n* roles delegated by *bins* specify the
-project's distribution, then the project is considered to be non-existent on
-PyPI.
+This PEP proposes that the *bin-n* roles sign for all PyPI projects with online
+keys. They MUST all be delegated by the upper-level *bins* role, which is signed
+with an offline key, and in turn MUST be delegated by the top-level *targets*
+role, which is also signed with an offline key.
+This means that when a package manager such as pip (i.e., using TUF) downloads
+a distribution from a project on PyPI, it will consult the *targets* role about
+the TUF metadata for the project.  If ultimately no *bin-n* roles delegated by
+*targets* via *bins* specify the project's distribution, then the project is
+considered to be non-existent on PyPI.
+
+Note, the reason why *targets* does not directly delegate to *bin-n*, but
+instead uses the intermediary *bins* role, is so that other delegations can
+easily be added or removed, without affecting the *bins*-to-*bin-n* mapping.
+This is crucial for the implementation of PEP 480 [26]_.
 
 
 Metadata Expiry Times


### PR DESCRIPTION
Closes #23 

Clarify why *targets* does not directly delegate to *bin-n* roles, but instead delegates to the *bins* role, which in turn delegates to *bin-n* roles.


