### PR TITLE
Remove Appendix C

### DIFF
--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -258,11 +258,25 @@ Integrating PyPI with TUF
 =========================
 
 A software update system must complete two main tasks to integrate with TUF.
-First, it must add the framework to the client side of the update system.  For
-example, TUF MAY be integrated with the pip package manager.  Second, the
-repository on the server side MUST be modified to provide signed TUF metadata.
-This PEP is concerned with the second part of the integration, and the changes
-on PyPI required to support software updates with TUF.
+First, it must add the framework to the client side of the update system. For
+example, TUF MAY be integrated with the pip package manager. Thus, new versions
+of pip going forward SHOULD use TUF by default to download and verify packages
+from PyPI before installing them. However, there may be unforeseen issues that
+might prevent users from installing or updating packages, including pip itself,
+via TUF. Therefore, pip MAY provide an undocumented option
+(e.g., `--no-pep-458`) in order to work around such issues until they are
+resolved.
+
+Second, the repository on the server side MUST be modified to provide signed
+TUF metadata. This PEP is concerned with the second part of the integration,
+and the changes on PyPI required to support software updates with TUF.
+We assume that pip would use TUF to verify packages downloaded only from PyPI.
+pip MAY support TAP 4__ in order use TUF to also verify packages downloaded
+from elsewhere__.
+
+__ https://github.com/theupdateframework/taps/blob/master/tap4.md
+__ https://www.python.org/dev/peps/pep-0470/
+
 
 
 What Additional Repository Files are Required on PyPI?
@@ -1062,54 +1076,6 @@ Appendix A: Repository Attacks Prevented by TUF
   This includes relying on a single online key, such as only being protected
   by SSL, or a single offline key, as most software update systems use
   to sign files.
-
-
-Appendix C: PEP 470 and Projects Hosted Externally
-==================================================
-
-How should TUF handle distributions that are not hosted on PyPI?  According to
-`PEP 470`__, projects may opt to host their distributions externally and are
-only required to provide PyPI a link to its external index, which package
-managers like pip can use to find the project's distributions.  PEP 470 does
-not mention whether externally hosted projects are considered unverified by
-default, as projects that use this option are not required to submit any
-information about their distributions (e.g., file size and cryptographic hash)
-when the project is registered, nor include a cryptographic hash of the file
-in download links.
-
-__ http://www.python.org/dev/peps/pep-0470/
-
-Potential approaches that PyPI administrators MAY consider to handle
-projects hosted externally:
-
-1.  Download external distributions but do not verify them.  The targets
-    metadata will not include information for externally hosted projects.
-
-2.  PyPI will periodically download information from the external index.  PyPI
-    will gather the external distribution's file size and hashes and generate
-    appropriate TUF metadata.
-
-3.  External projects MUST submit the file size and cryptographic hash to PyPI
-    for a distribution.
-
-4.  External projects MUST upload to PyPI a developer public key for the
-    index.  The distribution MUST create TUF metadata that is stored at the
-    index, and signed with the developer's corresponding private key.  The
-    client will fetch the external TUF metadata as part of the package
-    update process.
-
-5.  External projects MUST upload signed TUF metadata to PyPI (as allowed by
-    the maximum security model) about the distributions that they host
-    externally, along with a developer public key.  Package managers verify
-    distributions by consulting the signed metadata uploaded to PyPI.
-
-Only one of the options listed above should be implemented on PyPI.  Option
-(4) or (5) is RECOMMENDED because external distributions are signed by
-developers. External distributions that are forged (due to a compromised
-PyPI account or external host) may be detected if external developers are
-required to sign metadata, although this requirement is likely only practical
-if an easy-to-use key management solution and developer scripts are provided
-by PyPI.
 
 
 References


### PR DESCRIPTION
Remove Appendix C, which talks about repos other than PyPI. However, we now say:

* Going forward, pip would use TUF by default to verify packages from PyPI.
* It MAY use TAP 4 to support other repos.
* It MAY use an undocumented option to allow users to install/update packages despite unexpected issues from PEP 458.