### PR TITLE
Cost for new users

### DIFF
--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -489,7 +489,7 @@ for all users would effectively be the cost for new users, because their cost
 would be dominated by the (once-in-a-while) cost of downloading the large
 number of delegations in the `bins` metadata. If the cost for new users
 should prove to be too much due to the overhead of downloading the `bins`
-metadata upon installation, then this subject SHOULD be revisited before that
+metadata, then this subject SHOULD be revisited before that
 happens.
 
 Note that changes to the number of bins on the server are transparent to the

--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -488,7 +488,7 @@ number of bins stay fixed. If the number of bins is increased, then the cost
 for all users would effectively be the cost for new users, because their cost
 would be dominated by the (once-in-a-while) cost of downloading the large
 number of delegations in the `bins` metadata. If the cost for new users
-should prove to be too much due to the overhead of downloading the `bins`
+should prove to be too much, primarily due to the overhead of downloading the `bins`
 metadata, then this subject SHOULD be revisited before that
 happens.
 

--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -488,8 +488,9 @@ number of bins stay fixed. If the number of bins is increased, then the cost
 for all users would effectively be the cost for new users, because their cost
 would be dominated by the (once-in-a-while) cost of downloading the large
 number of delegations in the `bins` metadata. If the cost for new users
-should prove to be too much, then this subject SHOULD be revisited before
-that happens.
+should prove to be too much due to the overhead of downloading the `bins`
+metadata upon installation, then this subject SHOULD be revisited before that
+happens.
 
 Note that changes to the number of bins on the server are transparent to the
 client.  The package manager will be required to download a fresh set of


### PR DESCRIPTION
Fixes #45 

Explain that the bins metadata delegations are the cause of the cost for new users