### PR TITLE
Clarifications around offline key ceremony and one-time initialisation of bin-n metadata

### DIFF
--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -601,8 +601,8 @@ MAY be online in the private infrastructure of the project.
 There SHOULD be an offline key ceremony to generate, backup, and store these
 keys in such a manner that the private keys can be read only by the Python
 administrators when necessary (e.g., such as rotating the keys for the
-top-level TUF roles). Thus, keys SHOULD be generated—preferably in a physical
-location where side-channel attacks__ are not a concern—using:
+top-level TUF roles). Thus, keys SHOULD be generated, preferably in a physical
+location where side-channel attacks__ are not a concern, using:
 
 1. A trusted, airgapped__ computer with a true random number generator__, and
    with no **data** persisting after the ceremony

--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -369,6 +369,12 @@ generate cryptographic keys, and manage a TUF repository.
 
 __ https://github.com/theupdateframework/tuf/blob/v0.11.1/docs/TUTORIAL.md#how-to-create-and-modify-a-tuf-repository
 
+In standard operation, the *bin-n* metadata will be updated and signed as new
+distributions are uploaded to PyPI. However, there will also need to be a
+one-time online initialization mechanism to create and sign *bin-n* metadata for
+all existing distributions that are part of the PyPI repository every time PyPI
+is re-initialized.
+
 
 How to Establish Initial Trust in the PyPI Root Keys
 ----------------------------------------------------

--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -607,8 +607,9 @@ location where side-channel attacks__ are not a concern, using:
 1. A trusted, airgapped__ computer with a true random number generator__, and
    with no **data** persisting after the ceremony
 2. A trusted operating system
-3. A trusted set of third-party packages (e.g., cryptographic libraries, the
-   TUF reference implementation)
+3. A trusted set of third-party packages (such as updated versions of
+   cryptographic libraries or the TUF reference implementation, where the
+   versions provided by the trusted operating system are not recent enough)
 
 __ https://en.wikipedia.org/wiki/Side-channel_attack
 __ https://en.wikipedia.org/wiki/Air_gap_(networking)
@@ -629,16 +630,23 @@ Passwords used to encrypt keys SHOULD be stored somewhere durable and
 trustworthy to which only Python admins have access.
 
 In order to minimize OPSEC__ errors during the ceremony, scripts SHOULD be
-written to automate tedious parts, such as:
+written, for execution on the trusted key-generation computer, to automate
+tedious steps of the ceremony, such as:
 
 - Exporting to sneakernet__ all code and data (e.g., previous TUF metadata,
   targets, and *root* keys) required to generate new keys and replace old ones
 - Tightening the firewall, updating the entire operating system in order to
   fix security vulnerabilities, and airgapping the computer
-- Printing and saving cryptographic hashes of new TUF metadata
-- Exporting *all* new TUF metadata, targets, and keys to encrypted backup media
+- Exporting *all* new TUF metadata, targets, and keys to encrypted backup media.
+  This backup provides a complete copy of the data required to restore the PyPI
+  TUF repository
 - Exporting *only* new TUF metadata, targets, and online keys to encrypted backup
-  media
+  media. This backup provides all online data for import into the PyPI
+  infrastructure and is useful, e.g., when the online data needs to be restored
+  from a previous archived state
+- Printing and saving cryptographic hashes of new TUF metadata. This printed copy
+  provides an additional offline paper backup, which can be used as a comparison
+  in the case of a compromise
 
 __ https://en.wikipedia.org/wiki/Operations_security
 __ https://en.wikipedia.org/wiki/Sneakernet

--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -633,17 +633,17 @@ In order to minimize OPSEC__ errors during the ceremony, scripts SHOULD be
 written, for execution on the trusted key-generation computer, to automate
 tedious steps of the ceremony, such as:
 
-- Exporting to sneakernet__ all code and data (e.g., previous TUF metadata,
-  targets, and *root* keys) required to generate new keys and replace old ones
+- Exporting to sneakernet__ all code and data (previous TUF metadata and *root*
+  keys) required to generate new keys and replace old ones
 - Tightening the firewall, updating the entire operating system in order to
   fix security vulnerabilities, and airgapping the computer
-- Exporting *all* new TUF metadata, targets, and keys to encrypted backup media.
+- Exporting *all* new TUF metadata and keys to encrypted backup media.
   This backup provides a complete copy of the data required to restore the PyPI
   TUF repository
-- Exporting *only* new TUF metadata, targets, and online keys to encrypted backup
-  media. This backup provides all online data for import into the PyPI
-  infrastructure and is useful, e.g., when the online data needs to be restored
-  from a previous archived state
+- Exporting *only* new TUF metadata and online keys to encrypted backup media.
+  This backup provides all online data for import into the PyPI infrastructure
+  and is useful, e.g., when the online data needs to be restored from a previous
+  archived state
 - Printing and saving cryptographic hashes of new TUF metadata. This printed copy
   provides an additional offline paper backup, which can be used as a comparison
   in the case of a compromise


### PR DESCRIPTION
This is my attempt to address the comments in #22 by 
* clarifying some steps of the offline key ceremony
* removing references to target files in the offline key ceremony
* adding mention of a one-time initialisation to add and sign bin-n metadata for existing distributions