### PR TITLE
Revise consistent snapshots sections

### DIFF
--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -715,6 +715,11 @@ produces another snapshot.
 
 __ https://en.wikipedia.org/wiki/Collision_(computer_science)
 
+Clients, such as pip, using the TUF protocol MUST be modified to download
+every metadata and target file (except for *timestamp* metadata) by including,
+in the file request, the version of the file (for metadata), or the
+cryptographic hash of the file (for target files) in the filename.
+
 In this simple but effective manner, PyPI is able to capture a consistent
 snapshot of all projects and the associated metadata at a given time.  The next
 subsection provides implementation details of this idea.
@@ -796,48 +801,31 @@ errors after a server failure.
 __ https://en.wikipedia.org/wiki/Transaction_log
 
 
+Cleaning up old metadata
+------------------------
 
+To avoid running out of disk space, by constantly producing new consistent
+snapshots, PyPI SHOULD regularly delete old consistent snapshots, i.e. metadata
+and target files that were obsoleted some reasonable time in the past, such as
+1 hour.
 
+In order to preserve the latest consistent snapshot PyPI MAY use a
+"mark-and-sweep" algorithm. That is, walk from the root of the latest
+consistent snapshot, i.e. *timestamp* over *snapshot* over *targets* and
+delegated targets until the target files, marking all visited files, and
+delete all unmarked files. The last few consistent snapshots may be preserved
+in a similar fashion.
 
-# TODO: I think we can move down/ merge below paragraphs with "Cleaning up old metadata"
-
-
-At this stage, its important to acknowledge a few implementation notes.  So far, we have seen only that
-new metadata and targets are added, but not that old metadata and targets are
-removed.  Practical constraints are such that eventually PyPI will run out of
-disk space to produce a new consistent snapshot.  In that case, PyPI MAY then
-use something like a "mark-and-sweep" algorithm to delete sufficiently old
-consistent snapshots. In order to preserve the latest consistent snapshot, PyPI
-should walk objects beginning from the root (*timestamp*) of the latest
-consistent snapshot, mark all visited objects, and delete all unmarked objects.
-The last few consistent snapshots may be preserved in a similar fashion.
 Deleting a consistent snapshot will cause clients to see nothing except HTTP
 404 responses to any request for a file within that consistent snapshot.
 Clients SHOULD then retry their requests (as before) with the latest consistent
 snapshot.
 
-All clients, such as pip, using the TUF protocol MUST be modified to download
-every metadata and target file (except for *timestamp* metadata) by including,
-in the file request, the version of the file (for metadata), or the
-cryptographic hash of the file (for target files) in the filename.
+Note that *root* metadata, even though versioned, is not part of any consistent
+snapshot. PyPI MUST NOT delete old versions of *root* metadata. This guarantees
+that clients can update to the latest *root* role keys, no matter how outdated
+their local *root* metadata is.
 
-
-
-Cleaning up old metadata
-------------------------
-
-Prior versions of snapshot, targets, and timestamp metadata does not need to
-be kept indefinitely.  (Root files must be indefinitely retained.)
-However, a client that performs an update MUST be able
-to retrieve a consistent set of versions of the files on the repository.
-For example, if a client downloads a snapshot file, it should retrieve the versions
-of targets metadata that existed when that snapshot file was created, even if
-the targets metadata has been updated concurrently with the client requests.
-Fortunately, the use of hash / version delegations handle this case automatically
-since clients request targets unambiguously.  Once no client could reasonably
-be requesting outdated targets, snapshot or timestamp files, those files may be
-removed to save space.  Thus, files that were obsoleted some reasonable time
-in the past (such as 1 hour) may be safely discarded.
 
 Revoking Trust in Projects and Versions
 =======================================

--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -730,57 +730,77 @@ efficiently transfer consistent snapshots from PyPI.
 Producing Consistent Snapshots
 ------------------------------
 
-When given a project, PyPI is responsible for updating the *bin-n* metadata.  Every
-project MUST upload its release in a single transaction.  The uploaded set of
-files is called the "project transaction." How PyPI MAY validate the files in
-a project transaction is discussed in a later section.  For now, the focus is
-on how PyPI responds to a project transaction.
+When a new project release is uploaded to PyPI, PyPI MUST update the *bin-n*
+metadata responsible for the target files of the project release (remember that
+target files are sorted into bins by their filename hashes). Consequentially,
+PyPI MUST update *snaphot* to account for the updated *bin-n* metadata, and
+*timestamp* to account for the updated *snapshot* metadata. These updates
+SHOULD be handled by automated processes, e.g. one or more *transaction
+processes* and one *snapshot process*.
 
-When a project uploads a new transaction, the project transaction process MUST
-add all new targets and relevant delegated *bin-n* metadata. The process then MUST inform the snapshot process about any new
-*bin-n* metadata.
+The transaction process keeps track of a project upload, adds all new target
+files to the most recent, relevant *bin-n* metadata (in memory) and informs the
+snapshot process to produce a consistent snapshot. Each project release SHOULD
+be handled in an atomic transaction, so that a given consistent snapshot
+contains all target files of a project release. However, transaction processes
+MAY be parallelized under the following constraints:
 
-Project transaction processes SHOULD be automated and MUST also be applied
-atomically. This means either all metadata and targets -- or none of them -- are added.
-The project transaction and snapshot processes SHOULD work concurrently.
-Finally, project transaction processes SHOULD use the latest *bin-n*
-metadata so that they will be correctly updated in new consistent snapshots.
+- No pair of transaction processes MUST concurrently work on the same project.
+- No pair of transaction processes MUST concurrently work on projects that
+  belong to the same *bin-n* role.
 
-Signing updated *timestamp*, *snapshot*, and *bin-n* metadata needs to be done on each
-update.  Fortunately, the actual operation of signing is fast enough that this
-may be done a thousand or more times per second.  However, locking must be
-used so that project transactions are handled sequentially.  To achieve this,
-all project transactions MAY be placed in a single queue and processed
-serially.  Alternatively, the queue MAY be processed concurrently in order of
-appearance, provided that the following rules are observed:
+When a transaction process is finished updating the relevant *bin-n* metadata
+it informs the snapshot process to generate a new consistent snapshot. The
+snapshot process does so by taking the updated *bin-n* metadata, incrementing
+their respective version numbers, signing them with the *bin-n* role key(s),
+and writing them to *VERSION_NUMBER.bin-N.json*.
 
-1. No pair of project transaction processes must concurrently work on the same
-   project.
+Similarly, the snapshot process then takes the most recent *snapshot* metadata,
+updates its *bin-n* metadata hashes and version numbers, increments its own
+version number, signs it with the *snapshot* role key, and writes it to
+*VERSION_NUMBER.snapshot.json*.
 
-2. No pair of project transaction processes must concurrently work on
-   projects that belong to the same delegated *bin-n* role.
+And finally, the snapshot process takes the most recent *timestamp* metadata,
+updates its *snapshot* metadata hash and version number, increments its own
+version number, sets a new expiration time, signs it with the *timestamp* role
+key, and writes it to *timestamp.json*.
 
-These rules MUST be observed so that metadata is not read from or written to
-inconsistently.
+The snapshot process MUST generate consistent snapshots sequentially, reading
+the notifications received from the transaction process(es) from a
+concurrency-safe FIFO queue. Fortunately, the operation of signing is fast
+enough that this may be done a thousand or more times per second.
+
+The following caveats exist in regards to project transactions and immediate
+availability of target files:
+
+- PyPI allows adding files to a project release at arbitrary later times.
+- PyPI may want to make files available for download before all files of the
+  project release have been uploaded.
+
+To solve this, PyPI MAY define variable transaction windows that mark a
+transaction as finished even before all target files of a project release have
+been uploaded. A variable transaction window SHOULD be chosen so that a client,
+who downloads target files of a project release, is not left in an inconsistent
+state (with our without TUF metadata).
+Furthermore, the transaction window MAY only apply to the generation of a TUF
+consistent snapshot. That is, uploaded target files MAY become available for
+download immediately after being uploaded and before TUF has generated a
+consistent snapshot. If a user then downloads those target files in that short
+time frame, the client (e.g. pip) SHOULD warn the user about missing TUF
+protection and advice to abort download and try later.
+
+At any rate, PyPI SHOULD use a `transaction log`__ to record project
+transaction processes and the snapshot queue for auditing and to recover from
+errors after a server failure.
+
+__ https://en.wikipedia.org/wiki/Transaction_log
 
 
-Snapshot Process
-----------------
 
-The snapshot process is fairly simple and SHOULD be automated.  The snapshot
-process SHOULD use the latest working set of the *targets* and all
-delegated targets roles (i.e. *bins* and *bin-n* roles) metadata.  Upon an update, the
-snapshot process will sign for this
-latest working set.  (Recall that project transaction processes continuously
-inform the snapshot process about the latest delegated metadata in a
-concurrency-safe manner.  The snapshot process will actually sign for a copy of
-the latest working set while the latest working set in memory will be updated
-with information that is continuously communicated by the project transaction
-processes.)  The snapshot process MUST generate and sign new *timestamp*
-metadata that will vouch for the metadata (*root*, *targets*, and delegated
-roles) generated in the previous step.  Finally, the snapshot process MUST make
-the new *timestamp* and *snapshot* metadata representing
-the latest snapshot available to clients.
+
+
+# TODO: I think we can move down/ merge below paragraphs with "Cleaning up old metadata"
+
 
 At this stage, its important to acknowledge a few implementation notes.  So far, we have seen only that
 new metadata and targets are added, but not that old metadata and targets are
@@ -801,11 +821,6 @@ every metadata and target file (except for *timestamp* metadata) by including,
 in the file request, the version of the file (for metadata), or the
 cryptographic hash of the file (for target files) in the filename.
 
-Finally, PyPI SHOULD use a `transaction log`__ to record project transaction
-processes and queues so that it will be easier to recover from errors after a
-server failure.
-
-__ https://en.wikipedia.org/wiki/Transaction_log
 
 
 Cleaning up old metadata

--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -744,7 +744,7 @@ SHOULD be handled by automated processes, e.g. one or more *transaction
 processes* and one *snapshot process*.
 
 The transaction process keeps track of a project upload, adds all new target
-files to the most recent, relevant *bin-n* metadata (in memory) and informs the
+files to the most recent, relevant *bin-n* metadata and informs the
 snapshot process to produce a consistent snapshot. Each project release SHOULD
 be handled in an atomic transaction, so that a given consistent snapshot
 contains all target files of a project release. However, transaction processes
@@ -761,8 +761,8 @@ their respective version numbers, signing them with the *bin-n* role key(s),
 and writing them to *VERSION_NUMBER.bin-N.json*.
 
 Similarly, the snapshot process then takes the most recent *snapshot* metadata,
-updates its *bin-n* metadata hashes and version numbers, increments its own
-version number, signs it with the *snapshot* role key, and writes it to
+updates its *bin-n* metadata version numbers, increments its own version
+number, signs it with the *snapshot* role key, and writes it to
 *VERSION_NUMBER.snapshot.json*.
 
 And finally, the snapshot process takes the most recent *timestamp* metadata,
@@ -778,7 +778,8 @@ enough that this may be done a thousand or more times per second.
 The following caveats exist in regards to project transactions and immediate
 availability of target files:
 
-- PyPI allows adding files to a project release at arbitrary later times.
+- PyPI allows for upload of additional files for a release at any point in the
+  future.
 - PyPI may want to make files available for download before all files of the
   project release have been uploaded.
 
@@ -786,7 +787,7 @@ To solve this, PyPI MAY define variable transaction windows that mark a
 transaction as finished even before all target files of a project release have
 been uploaded. A variable transaction window SHOULD be chosen so that a client,
 who downloads target files of a project release, is not left in an inconsistent
-state (with our without TUF metadata).
+state (with or without TUF metadata).
 Furthermore, the transaction window MAY only apply to the generation of a TUF
 consistent snapshot. That is, uploaded target files MAY become available for
 download immediately after being uploaded and before TUF has generated a


### PR DESCRIPTION
Addresses #46

This PR provides a general revision of the "Producing Consistent Snapshots" and "Cleaning up old metadata" sections. My goal was to:
- clarify the work of the *transaction processes* and the *snapshot process*, i.e. what metadata they change, in what order and how (as this is quite a crucial part of an update system and IMO was described too vaguely before),
- address @ewdurbin's concerns in  https://github.com/python/peps/pull/1203#discussion_r336229332,
- shuffle some paragraph so that they fit better, 
  - e.g. the second half of the former "Snapshot Process" section was all about "Cleaning up old metadata", and
  - a paragraph about how clients should request metadata and targets in "Cleaning up old metadata" better fits into the general "Consistent Snapshot" section,
- emphasize that *root* metadata is not part of consistent snapshots and must not be removed, and
- remove some redundancy.

Apologies if I went too berserk, I did not intend to step on anyone's toes. 



