### PR TITLE
Revise target file related terminology

### DIFF
--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -85,7 +85,7 @@ Before the wiki attack, PyPI used MD5 hashes to tell package managers, such as
 pip, whether or not a distribution file was corrupted in transit.  However, the absence
 of SSL made it hard for package managers to verify transport integrity to PyPI.
 It was therefore easy to launch a man-in-the-middle attack between pip and
-PyPI, and change distribution content arbitrarily.  As a result, users could be tricked into
+PyPI, and arbitrarily change the content of distributions.  As a result, users could be tricked into
 installing malicious distributions.  After the wiki
 attack, several steps were proposed (some of which were implemented) to deliver
 a much higher level of security than was previously the case. These steps included
@@ -110,7 +110,7 @@ made to the Distutils mailing list showing that the latest version of pip (at
 the time) was susceptible to such attacks, and how TUF could protect users
 against them [14]_.  Specifically, testing was done to see how pip would
 respond to these attacks with and without TUF.  Attacks tested included replay
-and freeze, arbitrary distribution, slow retrieval, and endless data.  The post
+and freeze, arbitrary installation, slow retrieval, and endless data.  The post
 also included a demonstration of how pip would respond if PyPI were
 compromised.
 
@@ -166,16 +166,16 @@ Additional terms used in this PEP are defined as follows:
   has a single metadata file that it is trusted to provide.
 
 * Distribution file: A versioned archive file that contains Python packages,
-  modules, and other resource files that are used to distribute a release. In
-  this document a distribution file may also be referred to with the single
-  word distribution.
+  modules, and other resource files that are used to distribute a release. The
+  terms *distribution file*, *distribution package* [17]_, or simply
+  *distribution* or *package* may be used interchangeably in this PEP.
 
 * Simple index: The HTML page that contains internal links to distribution
   files.
 
 * Target files: As a rule of thumb, target files are all files on PyPI whose
   integrity should be guaranteed with TUF. Typically, this includes
-  distribution files, and PyPI metadata such as simple indices.
+  distribution files and PyPI metadata, such as simple indices.
 
 * Metadata: Metadata are signed files that describe roles, other metadata, and
   target files. If not specified otherwise metadata means TUF-specific
@@ -265,7 +265,7 @@ of pip going forward SHOULD use TUF by default to download and verify distributi
 from PyPI before installing them. However, there may be unforeseen issues that
 might prevent users from installing or updating distributions, including pip itself,
 via TUF. Therefore, pip SHOULD provide an option e.g.,
-`--unsafely-disable-distribution-verification`, in order to work around such issues
+`--unsafely-disable-package-verification`, in order to work around such issues
 until they are resolved. Note, the proposed option name is purposefully long,
 because a user must be helped to understand that the action is unsafe and not
 generally recommended.
@@ -1086,7 +1086,7 @@ information must be validated:
    projects will need to re-register their projects.
 
 3. If the target files themselves may have been tampered with, they can be
-   validated using the stored hash information for distributions that existed
+   validated using the stored hash information for target files that existed
    at the time of the last period.
 
 In order to safely restore snapshots in the event of a compromise, PyPI SHOULD

--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -82,35 +82,35 @@ possibility of security breaches and prepare PyPI accordingly because it is a
 valuable resource used by thousands, if not millions, of people.
 
 Before the wiki attack, PyPI used MD5 hashes to tell package managers, such as
-pip, whether or not a package was corrupted in transit.  However, the absence
+pip, whether or not a distribution file was corrupted in transit.  However, the absence
 of SSL made it hard for package managers to verify transport integrity to PyPI.
 It was therefore easy to launch a man-in-the-middle attack between pip and
-PyPI, and change package content arbitrarily.  As a result, users could be tricked into
-installing malicious packages.  After the wiki
+PyPI, and change distribution content arbitrarily.  As a result, users could be tricked into
+installing malicious distributions.  After the wiki
 attack, several steps were proposed (some of which were implemented) to deliver
 a much higher level of security than was previously the case. These steps included
 requiring SSL to
 communicate with PyPI [6]_, restricting project names [7]_, and migrating from
 MD5 to SHA-2 hashes [8]_.
 
-Though necessary, these steps are insufficient to protect packages because attacks are still
+Though necessary, these steps are insufficient to protect distributions because attacks are still
 possible through other avenues.  For example, a public mirror is trusted to
 honestly mirror PyPI, but some mirrors may misbehave, whether by accident or through
 malicious intervention.
 Package managers such as pip are supposed to use signatures from PyPI to verify
-packages downloaded from a public mirror [9]_, but none are known to actually
+distribution files downloaded from a public mirror [9]_, but none are known to actually
 do so [10]_.  Therefore, it would be wise to add more security measures to
 detect attacks from public mirrors or content delivery networks [11]_ (CDNs).
 
 Even though official mirrors have been deprecated on PyPI [12]_, a
 wide variety of other attack vectors on package managers remain [13]_.  These attacks
-can crash client systems, cause obsolete packages to be installed, or even
+can crash client systems, cause obsolete distributions to be installed, or even
 allow an attacker to execute arbitrary code.  In `September 2013`__, a post was
 made to the Distutils mailing list showing that the latest version of pip (at
 the time) was susceptible to such attacks, and how TUF could protect users
 against them [14]_.  Specifically, testing was done to see how pip would
 respond to these attacks with and without TUF.  Attacks tested included replay
-and freeze, arbitrary packages, slow retrieval, and endless data.  The post
+and freeze, arbitrary distribution, slow retrieval, and endless data.  The post
 also included a demonstration of how pip would respond if PyPI were
 compromised.
 
@@ -137,7 +137,7 @@ The threat model assumes the following:
 
 An attacker is considered successful if it can cause a client to install (or
 leave installed) something other than the most up-to-date version of a
-software package or file. If the attacker is preventing the installation
+software distribution file. If the attacker is preventing the installation
 of updates, they do not want clients to realize there is anything wrong.
 
 
@@ -154,41 +154,42 @@ This PEP focuses only on integrating TUF into PyPI. However, the reader is
 encouraged to review TUF design principles [2]_ and SHOULD be
 familiar with the TUF specification [16]_.
 
-Terms used in this PEP are defined as follows:
+The following terms used in this PEP are defined in the Python Packaging
+Glossary [17]_: *project*, *release*, *distribution*.
 
-* Projects: Projects are software components that are made available for
-  integration.  Projects include Python libraries, frameworks, scripts,
-  plugins, applications, collections of data or other resources, and various
-  combinations thereof.  Public Python projects are typically registered on the
-  Python Package Index [17]_.
+Additional terms used in this PEP are defined as follows:
 
-* Releases: Releases are uniquely identified snapshots of a project [17]_.
+* Role: TUF specifies one *root* role and multiple other roles to which the
+  *root* role delegates responsibilities, directly or indirectly. The term
+  *top-level* role refers to the *root* role and any role specified directly by
+  the *root* role, i.e. *timestamp*, *snapshot* and *targets* roles. Each role
+  has a single metadata file that it is trusted to provide.
 
-* Distributions: Distributions are the packaged files that are used to publish
-  and distribute a release [17]_.
+* Distribution file: A versioned archive file that contains Python packages,
+  modules, and other resource files that are used to distribute a release. In
+  this document a distribution file may also be referred to with the single
+  word distribution.
 
-* Simple index: The HTML page that contains internal links to the
-  distributions of a project [17]_.
+* Simple index: The HTML page that contains internal links to distribution
+  files.
 
-* Roles: There is one *root* role in PyPI.  There are multiple other roles for which the *root* role delegates
-  responsibilities, directly or indirectly. The term *top-level* role refers to the *root* role and any role
-  specified directly by the *root* role, i.e. *timestamp*, *snapshot* and
-  *targets* roles. Each role has a single metadata file that it is trusted to
-  provide.
+* Target files: As a rule of thumb, target files are all files on PyPI whose
+  integrity should be guaranteed with TUF. Typically, this includes
+  distribution files, and PyPI metadata such as simple indices.
 
 * Metadata: Metadata are signed files that describe roles, other metadata, and
-  target files.
+  target files. If not specified otherwise metadata means TUF-specific
+  metadata.
 
 * Repository: A repository is a source for named metadata and target
   files.  Clients request metadata and target files stored on a repository.
 
-* Consistent snapshot: A set of TUF metadata and PyPI targets that capture the
+* Consistent snapshot: A set of TUF metadata and target files that capture the
   complete state of all projects on PyPI as they existed at some fixed point in
   time.
 
 * Developer: Either the owner or maintainer of a project who is allowed to
-  update the TUF metadata, as well as distribution metadata and files for the
-  project.
+  update the TUF metadata, as well as target files for a project.
 
 * Online key: A private cryptographic key that MUST be stored on the PyPI
   server infrastructure.  This is usually to allow automated signing with the
@@ -260,11 +261,11 @@ Integrating PyPI with TUF
 A software update system must complete two main tasks to integrate with TUF.
 First, it must add the framework to the client side of the update system. For
 example, TUF MAY be integrated with the pip package manager. Thus, new versions
-of pip going forward SHOULD use TUF by default to download and verify packages
+of pip going forward SHOULD use TUF by default to download and verify distributions
 from PyPI before installing them. However, there may be unforeseen issues that
-might prevent users from installing or updating packages, including pip itself,
+might prevent users from installing or updating distributions, including pip itself,
 via TUF. Therefore, pip SHOULD provide an option e.g.,
-`--unsafely-disable-package-verification`, in order to work around such issues
+`--unsafely-disable-distribution-verification`, in order to work around such issues
 until they are resolved. Note, the proposed option name is purposefully long,
 because a user must be helped to understand that the action is unsafe and not
 generally recommended.
@@ -272,8 +273,8 @@ generally recommended.
 Second, the repository on the server side MUST be modified to provide signed
 TUF metadata. This PEP is concerned with the second part of the integration,
 and the changes on PyPI required to support software updates with TUF.
-We assume that pip would use TUF to verify packages downloaded only from PyPI.
-pip MAY support TAP 4__ in order use TUF to also verify packages downloaded
+We assume that pip would use TUF to verify distributions downloaded only from PyPI.
+pip MAY support TAP 4__ in order use TUF to also verify distributions downloaded
 from elsewhere__.
 
 __ https://github.com/theupdateframework/taps/blob/master/tap4.md
@@ -284,7 +285,7 @@ __ https://www.python.org/dev/peps/pep-0470/
 What Additional Repository Files are Required on PyPI?
 ------------------------------------------------------
 
-In order for package managers like pip to download and verify packages with
+In order for package managers like pip to download and verify distributions with
 TUF, a few extra files MUST be added to PyPI. These extra repository files are
 called TUF metadata, and they contain such information as which keys can be trusted,
 the `cryptographic hashes`__ of files, signatures, metadata version numbers, and
@@ -311,7 +312,7 @@ PyPI and TUF Metadata
 =====================
 
 TUF metadata provides information that clients can use to make update
-decisions.  For example, a *targets* metadata lists the available distributions
+decisions.  For example, a *targets* metadata lists the available target files
 on PyPI and includes the required signatures, cryptographic hashes, and
 file sizes for each.  Different metadata files provide different information, which are
 signed by separate roles. The *root* role indicates what metadata belongs to
@@ -360,7 +361,7 @@ The top-level *root* role signs for the keys of the top-level *timestamp*,
 *snapshot*, *targets*, and *root* roles.  The *timestamp* role signs for every
 new snapshot of the repository metadata.  The *snapshot* role signs for *root*,
 *targets*, and all delegated targets roles. The delegated targets role *bins*
-further delegates to the *bin-n* roles, which sign for all distributions
+further delegates to the *bin-n* roles, which sign for all distribution files
 belonging to registered PyPI projects.
 
 Figure 2 provides an overview of the roles available within PyPI, which
@@ -445,7 +446,7 @@ therefore, projects are safe from PyPI compromises.
 
 The minimum security model requires no action from a developer and protects
 against malicious CDNs [19]_ and public mirrors.  To support continuous
-delivery of uploaded packages, PyPI signs for projects with an online key.
+delivery of uploaded distributions, PyPI signs for projects with an online key.
 This level of security prevents projects from being accidentally or
 deliberately tampered with by a mirror or a CDN because neither will
 have any of the keys required to sign for projects.  However, it does not
@@ -457,9 +458,9 @@ keys. These *bin-n* roles MUST all be delegated by the upper-level *bins* role,
 which is signed with an offline key, and in turn MUST be delegated by the
 top-level *targets* role, which is also signed with an offline key.
 This means that when a package manager such as pip (i.e., using TUF) downloads
-a distribution from a project on PyPI, it will consult the *targets* role about
-the TUF metadata for the project.  If ultimately no *bin-n* roles delegated by
-*targets* via *bins* specify the project's distribution, then the project is
+a distribution file from a project on PyPI, it will consult the *targets* role about
+the TUF metadata for that distribution file.  If ultimately no *bin-n* roles
+delegated by *targets* via *bins* specify the distribution file, then it is
 considered to be non-existent on PyPI.
 
 Note, the reason why *targets* does not directly delegate to *bin-n*, but
@@ -504,7 +505,7 @@ split all targets in the *bins* role by delegating them to 16,384
 for the PyPI targets whose SHA2-256 hashes fall into that bin
 (see and Figure 2 and `Consistent Snapshots`_). It was found
 that this number of bins would result in a 12-22% metadata overhead
-(relative to the average size of downloaded packages; see V14 and
+(relative to the average size of downloaded distribution files; see V14 and
 V16 in Table 2) for returning users, and a 153% overhead for new
 users who are installing pip for the first time (see V18 in Table 2).
 
@@ -514,73 +515,73 @@ A few assumptions used in calculating these metadata overhead percentages:
 2. pip will always be bundled with the latest good copy of metadata for all
    roles.
 
-+------+---------------------------------------------+-----------+
-| Name | Description                                 | Value     |
-+------+---------------------------------------------+-----------+
-| C1   | # of bytes in a SHA2-256 hexadecimal digest | 64        |
-+------+---------------------------------------------+-----------+
-| C2   | # of bytes in a SHA2-512 hexadecimal digest | 128       |
-+------+---------------------------------------------+-----------+
-| C3   | # of bytes for a SHA2-256 public key ID     | 64        |
-+------+---------------------------------------------+-----------+
-| C4   | # of bytes for an Ed25519 signature         | 128       |
-+------+---------------------------------------------+-----------+
-| C5   | # of bytes for an Ed25519 public key        | 64        |
-+------+---------------------------------------------+-----------+
-| C6   | # of bytes for a target relative file path  | 256       |
-+------+---------------------------------------------+-----------+
-| C7   | # of bytes to encode a target file size     | 7         |
-+------+---------------------------------------------+-----------+
-| C8   | # of bytes to encode a version number       | 6         |
-+------+---------------------------------------------+-----------+
-| C9   | # of targets (simple indices and packages)  | 2,195,135 |
-+------+---------------------------------------------+-----------+
-| C10  | Average # of bytes for a downloaded package | 1,000,000 |
-+------+---------------------------------------------+-----------+
-| C11  | # of bins                                   | 16,384    |
-+------+---------------------------------------------+-----------+
++------+--------------------------------------------------+-----------+
+| Name | Description                                      | Value     |
++------+--------------------------------------------------+-----------+
+| C1   | # of bytes in a SHA2-256 hexadecimal digest      | 64        |
++------+--------------------------------------------------+-----------+
+| C2   | # of bytes in a SHA2-512 hexadecimal digest      | 128       |
++------+--------------------------------------------------+-----------+
+| C3   | # of bytes for a SHA2-256 public key ID          | 64        |
++------+--------------------------------------------------+-----------+
+| C4   | # of bytes for an Ed25519 signature              | 128       |
++------+--------------------------------------------------+-----------+
+| C5   | # of bytes for an Ed25519 public key             | 64        |
++------+--------------------------------------------------+-----------+
+| C6   | # of bytes for a target relative file path       | 256       |
++------+--------------------------------------------------+-----------+
+| C7   | # of bytes to encode a target file size          | 7         |
++------+--------------------------------------------------+-----------+
+| C8   | # of bytes to encode a version number            | 6         |
++------+--------------------------------------------------+-----------+
+| C9   | # of targets (simple indices and distributions)  | 2,195,135 |
++------+--------------------------------------------------+-----------+
+| C10  | Average # of bytes for a downloaded distribution | 1,000,000 |
++------+--------------------------------------------------+-----------+
+| C11  | # of bins                                        | 16,384    |
++------+--------------------------------------------------+-----------+
 
 Table 1: A list of constants used to calculate metadata overhead.
 
-+------+-------------------------------------------------------------------------------+------------------------------+-----------+
-| Name | Description                                                                   | Formula                      | Value     |
-+------+-------------------------------------------------------------------------------+------------------------------+-----------+
-| V1   | Length of a path hash prefix                                                  | math.ceil(math.log(C11, 16)) | 4         |
-+------+-------------------------------------------------------------------------------+------------------------------+-----------+
-| V2   | Total # of path hash prefixes                                                 | 16**V1                       | 65,536    |
-+------+-------------------------------------------------------------------------------+------------------------------+-----------+
-| V3   | Avg # of targets per bin                                                      | math.ceil(C9/C11)            | 134       |
-+------+-------------------------------------------------------------------------------+------------------------------+-----------+
-| V4   | Avg size of SHA-256 hashes per bin                                            | V3*C1                        | 8,576     |
-+------+-------------------------------------------------------------------------------+------------------------------+-----------+
-| V5   | Avg size of SHA-512 hashes per bin                                            | V3*C2                        | 17,152    |
-+------+-------------------------------------------------------------------------------+------------------------------+-----------+
-| V6   | Avg size of target paths per bin                                              | V3*C6                        | 34,304    |
-+------+-------------------------------------------------------------------------------+------------------------------+-----------+
-| V7   | Avg size of lengths per bin                                                   | V3*C7                        | 938       |
-+------+-------------------------------------------------------------------------------+------------------------------+-----------+
-| V8   | Avg size of bin-n metadata (bytes)                                            | V4+V5+V6+V7                  | 60,970    |
-+------+-------------------------------------------------------------------------------+------------------------------+-----------+
-| V9   | Total size of public key IDs in bins                                          | C11*C3                       | 1,048,576 |
-+------+-------------------------------------------------------------------------------+------------------------------+-----------+
-| V10  | Total size of path hash prefixes in bins                                      | V1*V2                        | 262,144   |
-+------+-------------------------------------------------------------------------------+------------------------------+-----------+
-| V11  | Est. size of bins metadata (bytes)                                            | V9+V10                       | 1,310,720 |
-+------+-------------------------------------------------------------------------------+------------------------------+-----------+
-| V12  | Est. size of snapshot metadata (bytes)                                        | C11*C8                       | 98,304    |
-+------+-------------------------------------------------------------------------------+------------------------------+-----------+
-| V13  | Est. size of metadata overhead per package per returning user (same snapshot) | 2*V8                         | 121,940   |
-+------+-------------------------------------------------------------------------------+------------------------------+-----------+
-| V14  | Est. metadata overhead per package per returning user (same snapshot)         | round((V13/C10)*100)         | 12%       |
-+------+-------------------------------------------------------------------------------+------------------------------+-----------+
-| V15  | Est. size of metadata overhead per package per returning user (diff snapshot) | V13+V12                      | 220,244   |
-+------+-------------------------------------------------------------------------------+------------------------------+-----------+
-| V16  | Est. metadata overhead per package per returning user (diff snapshot)         | round((V15/C10)*100)         | 22%       |
-+------+-------------------------------------------------------------------------------+------------------------------+-----------+
-| V17  | Est. size of metadata overhead per package per new user                       | V15+V11                      | 1,530,964 |
-+------+-------------------------------------------------------------------------------+------------------------------+-----------+
-| V18  | Est. metadata overhead per package per new user                               | round((V17/C10)*100)         | 153%      |
-+------+-------------------------------------------------------------------------------+------------------------------+-----------+
++------+------------------------------------------------------------------------------------+------------------------------+-----------+
+| Name | Description                                                                        | Formula                      | Value     |
++------+------------------------------------------------------------------------------------+------------------------------+-----------+
+| V1   | Length of a path hash prefix                                                       | math.ceil(math.log(C11, 16)) | 4         |
++------+------------------------------------------------------------------------------------+------------------------------+-----------+
+| V2   | Total # of path hash prefixes                                                      | 16**V1                       | 65,536    |
++------+------------------------------------------------------------------------------------+------------------------------+-----------+
+| V3   | Avg # of targets per bin                                                           | math.ceil(C9/C11)            | 134       |
++------+------------------------------------------------------------------------------------+------------------------------+-----------+
+| V4   | Avg size of SHA-256 hashes per bin                                                 | V3*C1                        | 8,576     |
++------+------------------------------------------------------------------------------------+------------------------------+-----------+
+| V5   | Avg size of SHA-512 hashes per bin                                                 | V3*C2                        | 17,152    |
++------+------------------------------------------------------------------------------------+------------------------------+-----------+
+| V6   | Avg size of target paths per bin                                                   | V3*C6                        | 34,304    |
++------+------------------------------------------------------------------------------------+------------------------------+-----------+
+| V7   | Avg size of lengths per bin                                                        | V3*C7                        | 938       |
++------+------------------------------------------------------------------------------------+------------------------------+-----------+
+| V8   | Avg size of bin-n metadata (bytes)                                                 | V4+V5+V6+V7                  | 60,970    |
++------+------------------------------------------------------------------------------------+------------------------------+-----------+
+| V9   | Total size of public key IDs in bins                                               | C11*C3                       | 1,048,576 |
++------+------------------------------------------------------------------------------------+------------------------------+-----------+
+| V10  | Total size of path hash prefixes in bins                                           | V1*V2                        | 262,144   |
++------+------------------------------------------------------------------------------------+------------------------------+-----------+
+| V11  | Est. size of bins metadata (bytes)                                                 | V9+V10                       | 1,310,720 |
++------+------------------------------------------------------------------------------------+------------------------------+-----------+
+| V12  | Est. size of snapshot metadata (bytes)                                             | C11*C8                       | 98,304    |
++------+------------------------------------------------------------------------------------+------------------------------+-----------+
+| V13  | Est. size of metadata overhead per distribution per returning user (same snapshot) | 2*V8                         | 121,940   |
++------+------------------------------------------------------------------------------------+------------------------------+-----------+
+| V14  | Est. metadata overhead per distribution per returning user (same snapshot)         | round((V13/C10)*100)         | 12%       |
++------+------------------------------------------------------------------------------------+------------------------------+-----------+
+| V15  | Est. size of metadata overhead per distribution per returning user (diff snapshot) | V13+V12                      | 220,244   |
++------+------------------------------------------------------------------------------------+------------------------------+-----------+
+| V16  | Est. metadata overhead per distribution per returning user (diff snapshot)         | round((V15/C10)*100)         | 22%       |
++------+------------------------------------------------------------------------------------+------------------------------+-----------+
+| V17  | Est. size of metadata overhead per distribution per new user                       | V15+V11                      | 1,530,964 |
++------+------------------------------------------------------------------------------------+------------------------------+-----------+
+| V18  | Est. metadata overhead per distribution per new user                               | round((V17/C10)*100)         | 153%      |
++------+------------------------------------------------------------------------------------+------------------------------+-----------+
 
 Table 2: Estimated metadata overheads for new and returning users.
 
@@ -774,9 +775,9 @@ How Should Metadata be Generated?
 Project developers expect the distributions they upload to PyPI to be
 immediately available for download.  Unfortunately, there will be problems when
 many readers and writers simultaneously access the same metadata and
-distributions.  That is, there needs to be a way to ensure consistency of
-metadata and repository files when multiple developers simultaneously change the
-same metadata or distributions.  There are also issues with consistency on PyPI
+target files.  That is, there needs to be a way to ensure consistency of
+metadata and target files when multiple developers simultaneously change these
+files. There are also issues with consistency on PyPI
 without TUF, but the problem is more severe with signed metadata that MUST keep
 track of the files available on PyPI in real-time.
 
@@ -932,13 +933,13 @@ that clients can update to the latest *root* role keys, no matter how outdated
 their local *root* metadata is.
 
 
-Revoking Trust in Projects and Versions
-=======================================
+Revoking Trust in Projects and Distributions
+============================================
 
-From time to time either a project or a version of a package will need to be revoked.
-To revoke trust in either a project or a version of a package, the associated bin-n role can 
-simply remove the corresponding targets and re-sign the bin-n metadata.  This action only 
-requires actions with the online bin-n key.
+From time to time either a project or a distribution will need to be revoked.
+To revoke trust in either a project or a distribution, the associated bin-n
+role can simply remove the corresponding targets and re-sign the bin-n
+metadata. This action only requires actions with the online bin-n key.
 
 
 
@@ -1084,9 +1085,9 @@ information must be validated:
    since the last period should be discarded. As a result, developers of new
    projects will need to re-register their projects.
 
-3. If the packages themselves may have been tampered with, they can be
-   validated using the stored hash information for packages that existed at the
-   time of the last period.
+3. If the target files themselves may have been tampered with, they can be
+   validated using the stored hash information for distributions that existed
+   at the time of the last period.
 
 In order to safely restore snapshots in the event of a compromise, PyPI SHOULD
 maintain a small number of its own mirrors to copy PyPI snapshots according to
@@ -1100,12 +1101,12 @@ periodically and tweet it.  Perhaps a user comes forward with the actual
 metadata and the repository maintainers can verify the metadata file's cryptographic
 hash.  Alternatively, PyPI may periodically archive its own versions of
 *snapshot* rather than rely on externally provided metadata.  In this case,
-PyPI SHOULD take the cryptographic hash of every package on the repository and
-store this data on an offline device. If any package hash has changed, this
-indicates an attack.
+PyPI SHOULD take the cryptographic hash of every target file on the
+repository and store this data on an offline device. If any target file
+hash has changed, this indicates an attack.
 
 As for attacks that serve different versions of metadata, or freeze a version
-of a package at a specific version, they can be handled by TUF with techniques
+of a distribution at a specific version, they can be handled by TUF with techniques
 like implicit key revocation and metadata mismatch detection [2]_.
 
 
@@ -1119,7 +1120,7 @@ see the ongoing discussion in the TAP repository__.
 __ https://github.com/theupdateframework/taps/pull/107
 
 Note that the changes to PyPI from this PEP will be backwards compatible. The
-location of targets files and simple indices are not changed in this PEP, so any
+location of target files and simple indices are not changed in this PEP, so any
 existing PyPI clients will still be able to perform updates using these files.
 This PEP adds the ability for clients to use TUF metadata to improve the
 security of the update process.
@@ -1194,8 +1195,7 @@ References
 .. [14] https://mail.python.org/pipermail/distutils-sig/2013-September/022755.html
 .. [15] http://ed25519.cr.yp.to/
 .. [16] https://github.com/theupdateframework/specification/blob/master/tuf-spec.md
-.. [17] PEP 426, Metadata for Python Software Packages 2.0, Coghlan, Holth, Stufft
-        http://www.python.org/dev/peps/pep-0426/
+.. [17] https://packaging.python.org/glossary
 .. [18] https://en.wikipedia.org/wiki/Continuous_delivery
 .. [19] https://mail.python.org/pipermail/distutils-sig/2013-August/022154.html
 .. [20] https://en.wikipedia.org/wiki/Key-recovery_attack


### PR DESCRIPTION
- Update link to python package glossary (used to point to outdated PEP 426).
- Remove terms "projects", "releases" and "distributions" from definitions sections and refer the reader to the PPA glossary.
- Add definition for "distribution file" and clarify that it means "distribution package" as defined in the PPA glossary and may be referred to by the single word "distribution" in  this document.
- Add definition for target files.
- Use *distribution* or *distribution file*, or *target file*, instead of *package* throughout the document.
