### PR TITLE
Update metadata calc in text after removing sha256

### DIFF
--- a/pep-0458.txt
+++ b/pep-0458.txt
@@ -554,9 +554,9 @@ split all targets in the *bins* role by delegating them to 16,384
 *bin-n* roles (see C10 in Table 2). Each *bin-n* role would sign
 for the PyPI targets whose SHA2-512 hashes fall into that bin
 (see and Figure 2 and `Consistent Snapshots`_). It was found
-that this number of bins would result in a 6-10% metadata overhead
+that this number of bins would result in a 5-9% metadata overhead
 (relative to the average size of downloaded distribution files; see V13 and
-V15 in Table 3) for returning users, and a 70% overhead for new
+V15 in Table 3) for returning users, and a 69% overhead for new
 users who are installing pip for the first time (see V17 in Table 3).
 
 
@@ -590,7 +590,7 @@ A few assumptions used in calculating these metadata overhead percentages:
 | C10  | # of bins                                        | 16,384    |
 +------+--------------------------------------------------+-----------+
 
-C8 by computed querying the number of release files.
+C8 was computed by querying the number of release files.
 C9 was derived by taking the average between a rough estimate of the average
 size of release files *downloaded* over the past 31 days (1,628,321 bytes),
 and the average size of releases files on disk (2,740,465 bytes).
@@ -645,8 +645,8 @@ __ https://docs.google.com/spreadsheets/d/11_XkeHrf4GdhMYVqpYWsug6JNz5ZK6HvvmDZX
 
 This number of bins SHOULD increase when the metadata overhead for returning
 users exceeds 50%. Presently, this SHOULD happen when the number of targets
-increase at least 8x from over 2M to over 18M, at which point the metadata
-overhead for returning and new users would be around 46-51% and 111%
+increase at least 10x from over 2M to over 22M, at which point the metadata
+overhead for returning and new users would be around 50-54% and 114%
 respectively, assuming that the number of bins stay fixed. If the number of
 bins is increased, then the cost for all users would effectively be the cost
 for new users, because their cost would be dominated by the (once-in-a-while)


### PR DESCRIPTION
https://github.com/secure-systems-lab/peps/pull/71 removed sha256 hashes from targets metadata and correctly updated the metadata calculation in the tables, but not in the text.

This PR updates the relevant numbers in the text.

It further fixes an unrelated wording mistake in the metadata calc section.
